### PR TITLE
Add link to Miro template

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,9 @@ Date:
 | .               |                  |         |          |
 | .               |                  |         |          |
 
+## Miro Template
+
+To help gather the information you could facilitate a session where everyone contributes to create your initial Team API.
+
+[Miro Template](https://miro.com/miroverse/team-topologies-team-api/) by [Radek Orszewski](https://www.linkedin.com/in/orszewski/)
+


### PR DESCRIPTION
In order to facilitate a session to create your teams Team API I've found this Miro template to come in handy.

It would be useful to others to immediately be able to find these resources while researching Team API's.